### PR TITLE
control scrolling down only inside chat UI/iframe not the parent window

### DIFF
--- a/src/app/(chat)/chatbot-embedding/[id]/components/chat.tsx
+++ b/src/app/(chat)/chatbot-embedding/[id]/components/chat.tsx
@@ -50,7 +50,7 @@ export const Chat = ({ id, className, missingKeys, chatbotId }: ChatProps) => {
     });
   }, [missingKeys]);
 
-  const { messagesRef, scrollRef, visibilityRef, isAtBottom, scrollToBottom } =
+  const { scrollRef, visibilityRef, isAtBottom, scrollToBottom } =
     useScrollAnchor();
 
   useEffect(() => {
@@ -99,10 +99,7 @@ export const Chat = ({ id, className, missingKeys, chatbotId }: ChatProps) => {
         </div>
       ) : (
         <>
-          <div
-            className={cn("pb-[200px] pt-4 md:pt-10", className)}
-            ref={messagesRef}
-          >
+          <div className={cn("pb-[200px] pt-4 md:pt-10", className)}>
             {messages.length ? (
               <ChatList messages={messages} />
             ) : (

--- a/src/app/(chat)/chatbot-embedding/[id]/lib/hooks/use-scroll-anchor.tsx
+++ b/src/app/(chat)/chatbot-embedding/[id]/lib/hooks/use-scroll-anchor.tsx
@@ -9,11 +9,8 @@ export const useScrollAnchor = () => {
   const [isVisible, setIsVisible] = useState(false);
 
   const scrollToBottom = useCallback(() => {
-    if (messagesRef.current) {
-      messagesRef.current.scrollIntoView({
-        block: "end",
-        behavior: "smooth",
-      });
+    if (scrollRef.current && visibilityRef.current) {
+      scrollRef.current.scrollTop = visibilityRef.current.offsetTop;
     }
   }, []);
 


### PR DESCRIPTION
## outline
There's a bug that the chatbot controls the entire window including the parent one when embedded via iframe.


https://github.com/user-attachments/assets/a92f0a10-a9a0-425d-9f1b-12fc848040b6

## how to fix
This article saved me :)
- https://stackoverflow.com/questions/20956663/scrollintoview-to-apply-to-iframe-only
- https://codecorner.galanter.net/2014/01/06/how-to-make-scrollintoview-apply-to-iframe-only/

